### PR TITLE
Remove ToC from user manual

### DIFF
--- a/documentation/user_manual.md
+++ b/documentation/user_manual.md
@@ -3,28 +3,6 @@
 This manual is designed to be readable by someone with basic knowledge of [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/).
 It is recommend to have a high-level understanding of [Encryptonize&reg;](https://github.com/cyber-crypt-com/encryptonize-core/), but it is not a strict requirement.
 
-- [User manual](#user-manual)
-  - [Overview](#overview)
-  - [Supported data types](#supported-data-types)
-  - [Storage format](#storage-format)
-    - [Overhead](#overhead)
-      - [Text data](#text-data)
-      - [Binary data](#binary-data)
-    - [Example](#example)
-  - [Usage](#usage)
-    - [Configure data context](#configure-data-context)
-      - [Using data annotations](#using-data-annotations)
-      - [Using Fluent API](#using-fluent-api)
-    - [Configure data model](#configure-data-model)
-      - [Using data annotations](#using-data-annotations-1)
-      - [Using Fluent API](#using-fluent-api-1)
-    - [Storing data](#storing-data)
-    - [Querying encrypted data](#querying-encrypted-data)
-    - [Fetching encrypted data](#fetching-encrypted-data)
-  - [Migrating existing data](#migrating-existing-data)
-    - [Example](#example-1)
-  - [Limitations](#limitations)
-
 ## Overview
 
 The integration works by encrypting and decrypting data transparently, using [Encryptonize&reg;](https://github.com/cyber-crypt-com/encryptonize-core/) when querying or storing in the database. Selected parts of the data is encrypted from the application to the database in such a way that the database itself never receives the data in plain text.


### PR DESCRIPTION
### Description
This doesn't work very well on the documentation websites,
as a ToC is automatically created on the website.

fixes WEB-39

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [ ] Refactor
- [ ] Bugfix
- [X] Updated documentation
- [ ] Kubernetes changes
- [ ] CI/CD workflow changes

### Testing Checklist
- [ ] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [X] I have pulled in the latest changes from master.
- [ ] I have run `make lint`.
- [ ] I have successfully run `make tests`.
- [ ] I have updated relevant CI/CD workflows.
- [ ] I have updated relevant Kubernetes manifests/scripts.
- [X] I have updated/added relevant (internal and external) documentation (readme, doc comments, etc).
- [ ] I have updated the dependency map to reflect my changes.
- [ ] I have added the license to new source code files.
- [X] I have spent some time looking over the full diff before creating this PR.

